### PR TITLE
Add 'isTouch' to force touchscreen mode

### DIFF
--- a/src/controlP5/ControlP5.java
+++ b/src/controlP5/ControlP5.java
@@ -148,6 +148,8 @@ public class ControlP5 extends ControlP5Base {
 	protected boolean isAnnotation;
 	boolean isAndroid = false;
 
+	public boolean isTouch = false;
+
 	/**
 	 * Create a new instance of controlP5.
 	 * 

--- a/src/controlP5/ControlWindow.java
+++ b/src/controlP5/ControlWindow.java
@@ -451,18 +451,32 @@ public final class ControlWindow {
 	 */
 	public void mouseEvent( MouseEvent theMouseEvent ) {
 		if ( isMouse ) {
+			final int action = theMouseEvent.getAction();
+
+			if ( cp5.isTouch ) {
+				// Ignore certain events when touch-enabled
+ 				if ( action == MouseEvent.CLICK || action == MouseEvent.MOVE ) {
+					return;
+				}
+			}
+
 			mouseX = theMouseEvent.getX( ) - cp5.pgx - cp5.ox;
 			mouseY = theMouseEvent.getY( ) - cp5.pgy - cp5.oy;
-			if ( theMouseEvent.getAction( ) == MouseEvent.PRESS ) {
+
+			if ( cp5.isTouch && ( action == MouseEvent.PRESS || action == MouseEvent.RELEASE ) ) {
+				// Use 'Android Mode' which is really just touchscreen support
+				mouseEvent( theMouseEvent.getX( ), theMouseEvent.getY( ), action == MouseEvent.PRESS );
+				return;
+			}
+
+			if ( action == MouseEvent.PRESS ) {
 				mousePressedEvent( );
 			}
-			if ( theMouseEvent.getAction( ) == MouseEvent.RELEASE ) {
+			if ( action == MouseEvent.RELEASE ) {
 				mouseReleasedEvent( );
 			}
-			if ( theMouseEvent.getAction( ) == MouseEvent.WHEEL ) {
-
+			if ( action == MouseEvent.WHEEL ) {
 				setMouseWheelRotation( theMouseEvent.getCount( ) );
-
 			}
 		}
 	}
@@ -531,7 +545,7 @@ public final class ControlWindow {
 		if ( cp5.blockDraw == false ) {
 			if ( cp5.isAndroid ) {
 				mouseEvent( cp5.papplet.mouseX , cp5.papplet.mouseY , cp5.papplet.mousePressed );
-			} else {
+			} else if ( !cp5.isTouch ) {
 				updateEvents( );
 			}
 			if ( isVisible ) {


### PR DESCRIPTION
This isn't necessarily a complete PR, but it fixes an issue I was seeing with controlp5 and touchscreens.

There are several reports of controlp5 not working well with touchscreens on the Processing forums: [1](https://forum.processing.org/two/discussion/4346/processing-application-on-a-touch-screen-tablet), [2](https://forum.processing.org/two/discussion/2929/how-to-use-touch), [3](https://forum.processing.org/two/discussion/4520/controlp5-button-behavior-on-touch-screen-devices), [4](https://forum.processing.org/two/discussion/13251/touch-screen-doesn-t-trigger-mousepressed). Most complaints mention that taps are registered at the previous tap location which is the behavior I observed. This behavior can be replicated on a non-touchscreen by having Processing ignore mouse move events.

After investigating the issue appears to be that controlp5 relies on the mouse hovering over a control (via mouse move) to mark it as inside before a press occurs. Since touchscreens won't have the mouse move events, this leads to the previous tap location problem where the mouse is only being marked as inside a control after it is tapped.

However, everything works fine on Android with a touchscreen due to the extra logic regarding Android (which seems to assume all Android devices are a touchscreen).

This PR adds a new 'isTouch' setting to the `ControlP5` class which can be used to manually enable touch mode. This switches controlp5 to using the Android method of handling mouse events, which correctly handles touchscreen style events. It also continues to work with a normal mouse with this mode enabled.

A better long-term fix may be to remove the logic that depends on a control having the mouse over it before it will function correctly.

This has ONLY been tested with buttons, I don't know that it for sure works with other controls. Logically it should so long as they work on Android.
