### PR TITLE
Change Vector to ArrayList

### DIFF
--- a/src/controlP5/ControllerList.java
+++ b/src/controlP5/ControllerList.java
@@ -1,5 +1,3 @@
-package controlP5;
-
 /**
  * controlP5 is a processing gui library.
  * 
@@ -22,47 +20,64 @@ package controlP5;
  * @author Andreas Schlegel (http://www.sojamo.de)
  * @modified ##date##
  * @version ##version##
- * 
  */
 
+package controlP5;
+
 import java.util.List;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.RandomAccess;
 
 /**
  * Stores objects of type ControllerInterface and CDrawable, mainly for internal use.
  */
-public class ControllerList {
+public class ControllerList implements RandomAccess {
+	protected final List< ControllerInterface< ? >> controllers = new ArrayList< >( );
+	protected final List< CDrawable > drawables = new ArrayList< >( );
 
-	protected List< ControllerInterface< ? >> controllers;
-
-	protected List< CDrawable > drawables;
-
-	public ControllerList( ) {
-		controllers = new Vector< ControllerInterface< ? >>( );
-		drawables = new Vector< CDrawable >( );
-	}
-
-	public void add( ControllerInterface< ? > theController ) {
-		if ( controllers.indexOf( theController ) < 0 ) {
+	public ControllerList add( final ControllerInterface< ? > theController ) {
+		if ( !contains( theController ) )  synchronized ( controllers ) {
 			controllers.add( theController );
 		}
+		return this;
 	}
 
-	protected void remove( ControllerInterface< ? > theController ) {
-		controllers.remove( theController );
-	}
-
-	protected void addDrawable( CDrawable theController ) {
-		if ( drawables.indexOf( theController ) < 0 ) {
+	public ControllerList addDrawable( final CDrawable theController ) {
+		if ( !containsDrawable( theController ) )  synchronized ( drawables ) {
 			drawables.add( theController );
 		}
+		return this;
 	}
 
-	protected void removeDrawable( CDrawable theController ) {
-		drawables.remove( theController );
+	public ControllerList remove( final ControllerInterface< ? > theController ) {
+		if ( !isEmpty( ) )  synchronized ( controllers ) {
+			controllers.remove( theController );
+		}
+		return this;
 	}
 
-	public ControllerInterface< ? > get( int theIndex ) {
+	public ControllerList removeDrawable( final CDrawable theController ) {
+		if ( !isEmptyDrawable( ) )  synchronized ( drawables ) {
+			drawables.remove( theController );
+		}
+		return this;
+	}
+
+	public ControllerList clear( ) {
+		if ( !isEmpty( ) )  synchronized ( controllers ) {
+			controllers.clear( );
+		}
+		return this;
+	}
+
+	public ControllerList clearDrawable( ) {
+		if ( !isEmptyDrawable( ) )  synchronized ( drawables ) {
+			drawables.clear( );
+		}
+		return this;
+	}
+
+	public ControllerInterface< ? > get( final int theIndex ) {
 		return controllers.get( theIndex );
 	}
 
@@ -70,7 +85,7 @@ public class ControllerList {
 		return controllers;
 	}
 
-	public CDrawable getDrawable( int theIndex ) {
+	public CDrawable getDrawable( final int theIndex ) {
 		return drawables.get( theIndex );
 	}
 
@@ -78,20 +93,27 @@ public class ControllerList {
 		return drawables;
 	}
 
-	public int sizeDrawable( ) {
-		return drawables.size( );
+	public boolean contains( final ControllerInterface< ? > theController ) {
+		return controllers.contains( theController );
+	}
+
+	public boolean containsDrawable( final CDrawable theController ) {
+		return drawables.contains( theController );
+	}
+
+	public boolean isEmpty( ) {
+		return controllers.isEmpty( );
+	}
+
+	public boolean isEmptyDrawable( ) {
+		return drawables.isEmpty( );
 	}
 
 	public int size( ) {
 		return controllers.size( );
 	}
 
-	protected void clear( ) {
-		controllers.clear( );
+	public int sizeDrawable( ) {
+		return drawables.size( );
 	}
-
-	protected void clearDrawable( ) {
-		drawables.clear( );
-	}
-
 }

--- a/src/controlP5/ControllerList.java
+++ b/src/controlP5/ControllerList.java
@@ -32,10 +32,10 @@ import java.util.RandomAccess;
  * Stores objects of type ControllerInterface and CDrawable, mainly for internal use.
  */
 public class ControllerList implements RandomAccess {
-	protected final List< ControllerInterface< ? > > controllers = new ArrayList< >( );
+	protected final List< ControllerInterface< ? extends ControllerInterface< ? > > > controllers = new ArrayList< >( );
 	protected final List< CDrawable > drawables = new ArrayList< >( );
 
-	public ControllerList add( final ControllerInterface< ? > theController ) {
+	public ControllerList add( final ControllerInterface< ? extends ControllerInterface< ? > > theController ) {
 		if ( !contains( theController ) )  synchronized ( controllers ) {
 			controllers.add( theController );
 		}
@@ -49,7 +49,7 @@ public class ControllerList implements RandomAccess {
 		return this;
 	}
 
-	public ControllerList remove( final ControllerInterface< ? > theController ) {
+	public ControllerList remove( final ControllerInterface< ? extends ControllerInterface< ? > > theController ) {
 		if ( !isEmpty( ) )  synchronized ( controllers ) {
 			controllers.remove( theController );
 		}
@@ -77,11 +77,11 @@ public class ControllerList implements RandomAccess {
 		return this;
 	}
 
-	public ControllerInterface< ? > get( final int theIndex ) {
+	public ControllerInterface< ? extends ControllerInterface< ? > > get( final int theIndex ) {
 		return controllers.get( theIndex );
 	}
 
-	public List< ControllerInterface< ? >> get( ) {
+	public List< ControllerInterface< ? extends ControllerInterface< ? > > > get( ) {
 		return controllers;
 	}
 
@@ -93,7 +93,7 @@ public class ControllerList implements RandomAccess {
 		return drawables;
 	}
 
-	public boolean contains( final ControllerInterface< ? > theController ) {
+	public boolean contains( final ControllerInterface< ? extends ControllerInterface< ? > > theController ) {
 		return controllers.contains( theController );
 	}
 

--- a/src/controlP5/ControllerList.java
+++ b/src/controlP5/ControllerList.java
@@ -32,7 +32,7 @@ import java.util.RandomAccess;
  * Stores objects of type ControllerInterface and CDrawable, mainly for internal use.
  */
 public class ControllerList implements RandomAccess {
-	protected final List< ControllerInterface< ? >> controllers = new ArrayList< >( );
+	protected final List< ControllerInterface< ? > > controllers = new ArrayList< >( );
 	protected final List< CDrawable > drawables = new ArrayList< >( );
 
 	public ControllerList add( final ControllerInterface< ? > theController ) {

--- a/src/controlP5/ControllerList.java
+++ b/src/controlP5/ControllerList.java
@@ -32,7 +32,7 @@ import java.util.RandomAccess;
  * Stores objects of type ControllerInterface and CDrawable, mainly for internal use.
  */
 public class ControllerList implements RandomAccess {
-	protected final List< ControllerInterface< ? extends ControllerInterface< ? > > > controllers = new ArrayList< >( );
+	protected final List< ControllerInterface< ? > > controllers = new ArrayList< >( );
 	protected final List< CDrawable > drawables = new ArrayList< >( );
 
 	public ControllerList add( final ControllerInterface< ? extends ControllerInterface< ? > > theController ) {
@@ -81,7 +81,7 @@ public class ControllerList implements RandomAccess {
 		return controllers.get( theIndex );
 	}
 
-	public List< ControllerInterface< ? extends ControllerInterface< ? > > > get( ) {
+	public List< ControllerInterface< ? > > get( ) {
 		return controllers;
 	}
 


### PR DESCRIPTION
Since **_ArrayList_** isn't safe like **_Vector_**, I'm also adding `synchronized ()` at places where either of its structure's **size()** changes.
Those 6 methods are: **add()**, **addDrawable()**, **remove()**, **removeDrawable()**, **clear()** and **clearDrawable()**.
Of course, all loops traversing this class still needs to be synchronized externally as well; either over **get()** or **getDrawables()**.
Last word: This patch is just a standalone performant refactoring. It's not obligatory for **_ControllerGroup_**'s previous patch.
