### PR TITLE
Label alignment bug has been fixed.

### DIFF
--- a/src/controlP5/Controller.java
+++ b/src/controlP5/Controller.java
@@ -1982,7 +1982,7 @@ public abstract class Controller< T > implements ControllerInterface< T > , CDra
 
 	public T align( int theCaptionX , int theCaptionY , int theValueX , int theValueY ) {
 		getCaptionLabel( ).align( theCaptionX , theCaptionY );
-		getCaptionLabel( ).align( theValueX , theValueY );
+		getValueLabel( ).align( theValueX , theValueY );
 		return me;
 	}
 


### PR DESCRIPTION
Controller::align incorrectly modified the alignment of the caption label twice. This patch fixes this issue.